### PR TITLE
Pin bibcop to 0.0.33 so braced {ACM} in booktitle passes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,8 @@ RUN apt-get -y update \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
-RUN wget --quiet --no-check-certificate https://yegor256.github.io/bibcop/bibcop.pl \
+ARG BIBCOP_VERSION=0.0.33
+RUN wget --quiet --no-check-certificate "https://raw.githubusercontent.com/yegor256/bibcop/${BIBCOP_VERSION}/bibcop.pl" \
   && mv bibcop.pl /usr/bin \
   && chmod a+x /usr/bin/bibcop.pl
 


### PR DESCRIPTION
The Dockerfile pulled bibcop from the gh-pages URL, so the bundled version was whatever happened to be latest when the image was last built and pushed. The published image drifted behind and keeps rejecting a brace-protected `{ACM}` token inside a `booktitle`, even though bibcop 0.0.33 (titled "wrapped 'ACM' token is not ignored in the booktitle") fixed exactly that.

This pins the download to the 0.0.33 tag via a `BIBCOP_VERSION` build arg, so the version is explicit and reproducible. I built the image locally and it now lints an entry with `booktitle = {{Proceedings of the {ACM} Annual Conference (Volume 2)}}` cleanly.

Once released, this unblocks yegor256/bibliography#21. A follow-up could wire Renovate to bump `BIBCOP_VERSION` automatically so the image stops drifting.